### PR TITLE
Update mailgun-php and add ability to specify server endpoints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,11 @@
     "nette/di": "~2.3.0|~2.4.0",
     "nette/mail": "~2.3.0|~2.4.0",
     "mailgun/mailgun-php": "~3.0.0",
-    "php-http/curl-client": "^1.7",
-    "guzzlehttp/psr7": "^1.6"
+    "guzzlehttp/psr7": "^1.6",
+    "http-interop/http-factory-guzzle": "^1.0",
+    "ricardofiorani/guzzle-psr18-adapter": "^1.0",
+    "php-http/discovery": "^1.7",
+    "psr/http-client": "^1.0"
   },
   "require-dev": {
     "nette/tester": "~1.7.0"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "nette/mail": "~2.3.0|~2.4.0",
     "mailgun/mailgun-php": "~3.0.0",
     "php-http/curl-client": "^1.7",
-    "guzzlehttp/psr7": "^1.4"
+    "guzzlehttp/psr7": "^1.6"
   },
   "require-dev": {
     "nette/tester": "~1.7.0"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "nette/bootstrap": "~2.3.0|~2.4.0",
     "nette/di": "~2.3.0|~2.4.0",
     "nette/mail": "~2.3.0|~2.4.0",
-    "mailgun/mailgun-php": "~2.3.4",
+    "mailgun/mailgun-php": "~3.0.0",
     "php-http/curl-client": "^1.7",
     "guzzlehttp/psr7": "^1.4"
   },

--- a/src/ondrs/MailgunMailer/DI/Extension.php
+++ b/src/ondrs/MailgunMailer/DI/Extension.php
@@ -12,7 +12,7 @@ class Extension extends CompilerExtension
     private $defaults = [
 		'apiKey' => NULL,
 		'domain' => NULL,
-		'servers' => 'https://api.mailgun.net',
+		'endpoint' => 'https://api.mailgun.net',
     ];
 
 
@@ -24,7 +24,7 @@ class Extension extends CompilerExtension
         $builder->addDefinition($this->prefix('mailgun'))
             ->setFactory('Mailgun\Mailgun::create', [
 				$config['apiKey'],
-				$config['servers']
+				$config['endpoint']
             ]);
 
         $builder->getDefinition('mail.mailer')

--- a/src/ondrs/MailgunMailer/DI/Extension.php
+++ b/src/ondrs/MailgunMailer/DI/Extension.php
@@ -10,8 +10,9 @@ class Extension extends CompilerExtension
 
     /** @var array */
     private $defaults = [
-        'apiKey' => NULL,
-        'domain' => NULL,
+		'apiKey' => NULL,
+		'domain' => NULL,
+		'servers' => 'https://api.mailgun.net',
     ];
 
 
@@ -22,7 +23,8 @@ class Extension extends CompilerExtension
 
         $builder->addDefinition($this->prefix('mailgun'))
             ->setFactory('Mailgun\Mailgun::create', [
-                $config['apiKey']
+				$config['apiKey'],
+				$config['servers']
             ]);
 
         $builder->getDefinition('mail.mailer')


### PR DESCRIPTION
Motivation: Use new EU servers which requires different API URL.

Solution: added config option `endpoint`

Note: I did run into dependency hell quite quickly. This state is somehow working, when you require `php-http/guzzle6-adapter` in an application but not the library itself.